### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require":
     {
         "php": ">=5.4",
-        "silverstripe/framework": ">=3.1.0"
+        "silverstripe/framework": "^3.1.0"
     },
     "require-dev": {
         "phpunit/PHPUnit": "~3.7@stable"


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.